### PR TITLE
Fix rails 5 deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - "1.9.3"
+  - "2.2.2"

--- a/lib/rack_strip_client_ip/railtie.rb
+++ b/lib/rack_strip_client_ip/railtie.rb
@@ -1,7 +1,7 @@
 module RackStripClientIp
   class Railtie < Rails::Railtie
     initializer "rack_strip_client_ip.insert_middleware" do |app|
-      app.config.middleware.insert_before 0, "RackStripClientIp::Middleware"
+      app.config.middleware.insert_before 0, RackStripClientIp::Middleware
     end
   end
 end

--- a/rack_strip_client_ip.gemspec
+++ b/rack_strip_client_ip.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rack-test", "0.6.2"
-  spec.add_development_dependency "rspec", "2.14.1"
+  spec.add_development_dependency "rack-test", "0.6.3"
+  spec.add_development_dependency "rspec", "3.6.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
This PR replaces the string reference to RackStripClientIp::Middleware,
because passing strings or symbols to middleware builder is now deprecated
in rails 5.